### PR TITLE
Change health check port from 18080 to 18081

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.19.5-1
+
+* Change health check port from `18080` to `18081`.
+
 ## 1.19.5
 
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ server {
 ## Logging
 
 To change how logging is configured, mount a file at `/etc/nginx/log.conf`:
-```nginx 
+```nginx
 access_log off;
 error_log off;
 ```
@@ -73,4 +73,4 @@ It's important to note that overriding this file will remove the current default
 
 ## Health check
 
-A health check is available on port `18080` at `/healthz`.
+A health check is available on port `18081` at `/healthz`.

--- a/config/http.conf
+++ b/config/http.conf
@@ -25,7 +25,7 @@ http {
   include /etc/nginx/app.conf;
 
   server {
-      listen 18080 default_server;
+      listen 18081 default_server;
 
       location /healthz {
           access_log off;


### PR DESCRIPTION
Because we have nginx running it's health check on 18080 which results in a port conflict (using [Intellection/docker-nginx](https://github.com/Intellection/docker-nginx)). Since we're running nginx-proxy on 8081 anyway (for the same reason), makes sense to use 18081. Here’s the error …

```
2021/01/07 09:45:11 [emerg] 1#1: bind() to 0.0.0.0:18080 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:18080 failed (98: Address in use)
2021/01/07 09:45:11 [emerg] 1#1: bind() to 0.0.0.0:18080 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:18080 failed (98: Address in use)
2021/01/07 09:45:11 [emerg] 1#1: bind() to 0.0.0.0:18080 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:18080 failed (98: Address in use)
2021/01/07 09:45:11 [emerg] 1#1: bind() to 0.0.0.0:18080 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:18080 failed (98: Address in use)
2021/01/07 09:45:11 [emerg] 1#1: bind() to 0.0.0.0:18080 failed (98: Address in use)
nginx: [emerg] bind() to 0.0.0.0:18080 failed (98: Address in use)
2021/01/07 09:45:11 [emerg] 1#1: still could not bind()
nginx: [emerg] still could not bind()
```