### PR TITLE
Forward X-Forwarded-* headers to upstream correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.19.5-2
+
+* Forward `X-Forwarded-*` headers to upstream.
+* Forward `Connection` header to upstream.
+
 ## 1.19.5-1
 
 * Change health check port from `18080` to `18081`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 1.19.5-2
 
-* Forward `X-Forwarded-*` headers to upstream.
-* Forward `Connection` header to upstream.
+* Forward `X-Forwarded-*` headers to upstream correctly.
 
 ## 1.19.5-1
 

--- a/config/http.conf
+++ b/config/http.conf
@@ -9,15 +9,36 @@ http {
   client_max_body_size  400m;
   client_body_timeout   300s;
 
+  # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+  # scheme used to connect to this server
+  map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+    default $http_x_forwarded_proto;
+    ''      $scheme;
+  }
+
+  # If we receive X-Forwarded-Proto, use it to determine the value of
+  # X-Forwarded-Ssl
+  map $http_x_forwarded_proto $proxy_x_forwarded_ssl {
+    default off;
+    https   on;
+  }
+
+  # If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
+  # server port the client connected to
+  map $http_x_forwarded_port $proxy_x_forwarded_port {
+    default $http_x_forwarded_port;
+    ''      $server_port;
+  }
+
   proxy_http_version  1.1;
   proxy_set_header    Connection          "";
   proxy_set_header    Host                $host;
 
   proxy_set_header    X-Real-IP           $remote_addr;
   proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-  proxy_set_header    X-Forwarded-Proto   $scheme;
-  proxy_set_header    X-Forwarded-Ssl     on;
-  proxy_set_header    X-Forwarded-Port    $server_port;
+  proxy_set_header    X-Forwarded-Proto   $proxy_x_forwarded_proto;
+  proxy_set_header    X-Forwarded-Ssl     $proxy_x_forwarded_ssl;
+  proxy_set_header    X-Forwarded-Port    $proxy_x_forwarded_port;
   proxy_set_header    X-Forwarded-Host    $host;
 
   proxy_read_timeout  600s;

--- a/config/http.conf
+++ b/config/http.conf
@@ -9,6 +9,13 @@ http {
   client_max_body_size  400m;
   client_body_timeout   300s;
 
+  # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
+  # Connection header that may have been passed to this server
+  map $http_upgrade $proxy_connection {
+    default upgrade;
+    '' close;
+  }
+
   # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
   # scheme used to connect to this server
   map $http_x_forwarded_proto $proxy_x_forwarded_proto {
@@ -31,7 +38,7 @@ http {
   }
 
   proxy_http_version  1.1;
-  proxy_set_header    Connection          "";
+  proxy_set_header    Connection          $proxy_connection;
   proxy_set_header    Host                $host;
 
   proxy_set_header    X-Real-IP           $remote_addr;

--- a/config/http.conf
+++ b/config/http.conf
@@ -9,13 +9,6 @@ http {
   client_max_body_size  400m;
   client_body_timeout   300s;
 
-  # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
-  # Connection header that may have been passed to this server
-  map $http_upgrade $proxy_connection {
-    default upgrade;
-    '' close;
-  }
-
   # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
   # scheme used to connect to this server
   map $http_x_forwarded_proto $proxy_x_forwarded_proto {
@@ -38,7 +31,7 @@ http {
   }
 
   proxy_http_version  1.1;
-  proxy_set_header    Connection          $proxy_connection;
+  proxy_set_header    Connection          "";
   proxy_set_header    Host                $host;
 
   proxy_set_header    X-Real-IP           $remote_addr;


### PR DESCRIPTION
Currently we fill incoming `X-Forwarded-*` headers with the request information it sees. This makes sure that we forward the incoming `X-Forwarded-*` headers (set my the L7 proxy/load-balancer) in front of it. I've also forwarded the `Connection` header. My view is that this is not necessary if your forwarding to an application web-server or if `nginx` is the app itself, but it becomes important if you're forwarding to another `nginx` instance that's filling in these same headers based on the information it sees. We could say the overall objective is that `nginx-proxy` should forward as much as it can and the upstream can decide what it needs or what it wants to modify from what's been passed to it.

#### References

* https://github.com/nginx-proxy/nginx-proxy/blob/0.8.0/nginx.tmpl
* https://github.com/kubernetes/ingress-nginx/blob/master/rootfs/etc/nginx/template/nginx.tmpl
* https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers
* https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html
* http://nginx.org/en/docs/http/ngx_http_map_module.html#map