### PR TITLE
Log format improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.19.5-4
+
+* Renamed `main` logging format to `main_default`.
+* Remove unnecessary double space between `$time_local` & `$status` from
+  `main_default` logging format.
+* Add `main_json` logging format and configure it on `access_log`.
+
 ## 1.19.5-3
 
 * Set or forward `X-Request-ID`.

--- a/config/log.conf
+++ b/config/log.conf
@@ -1,4 +1,4 @@
-log_format main '$remote_addr - $remote_user [$time_local]  $status '
+log_format main '$remote_addr - $remote_user [$time_local] $status '
                 '"$request" $body_bytes_sent "$http_referer" '
                 '"$http_user_agent" "$http_x_forwarded_for" $proxy_x_request_id';
 

--- a/config/log.conf
+++ b/config/log.conf
@@ -3,5 +3,21 @@ log_format main_default escape=default
   '"$request" $body_bytes_sent "$http_referer" '
   '"$http_user_agent" "$http_x_forwarded_for" $proxy_x_request_id';
 
+log_format main_json escape=json
+  '{'
+    '"body_bytes_sent":"$body_bytes_sent",'
+    '"http_referrer":"$http_referer",'
+    '"http_user_agent":"$http_user_agent",'
+    '"http_x_forwarded_for":"$http_x_forwarded_for",'
+    '"proxy_x_request_id":"$proxy_x_request_id",'
+    '"remote_addr":"$remote_addr",'
+    '"remote_user":"$remote_user",'
+    '"request":"$request",'
+    '"request_length":"$request_length",'
+    '"request_time":"$request_time",'
+    '"status": "$status",'
+    '"time_local":"$time_local"'
+  '}';
+
 access_log /dev/stdout main_default;
 error_log /dev/stdout warn;

--- a/config/log.conf
+++ b/config/log.conf
@@ -19,5 +19,5 @@ log_format main_json escape=json
     '"time_local":"$time_local"'
   '}';
 
-access_log /dev/stdout main_default;
+access_log /dev/stdout main_json;
 error_log /dev/stdout warn;

--- a/config/log.conf
+++ b/config/log.conf
@@ -1,6 +1,7 @@
-log_format main '$remote_addr - $remote_user [$time_local] $status '
-                '"$request" $body_bytes_sent "$http_referer" '
-                '"$http_user_agent" "$http_x_forwarded_for" $proxy_x_request_id';
+log_format main_default escape=default
+  '$remote_addr - $remote_user [$time_local] $status '
+  '"$request" $body_bytes_sent "$http_referer" '
+  '"$http_user_agent" "$http_x_forwarded_for" $proxy_x_request_id';
 
-access_log /dev/stdout main;
+access_log /dev/stdout main_default;
 error_log /dev/stdout warn;

--- a/config/log.conf
+++ b/config/log.conf
@@ -20,7 +20,7 @@ log_format main_json escape=json
     '"request_length":"$request_length",'
     '"request_time":"$request_time",'
     '"status": "$status",'
-    '"time_local":"$time_local"'
+    '"time_iso8601":"$time_iso8601"'
   '}';
 
 access_log /dev/stdout main_json;

--- a/config/log.conf
+++ b/config/log.conf
@@ -6,9 +6,13 @@ log_format main_default escape=default
 log_format main_json escape=json
   '{'
     '"body_bytes_sent":"$body_bytes_sent",'
+    '"host":"$host",'
     '"http_referrer":"$http_referer",'
     '"http_user_agent":"$http_user_agent",'
     '"http_x_forwarded_for":"$http_x_forwarded_for",'
+    '"proxy_x_forwarded_port":"$proxy_x_forwarded_port",'
+    '"proxy_x_forwarded_proto":"$proxy_x_forwarded_proto",'
+    '"proxy_x_forwarded_ssl":"$proxy_x_forwarded_ssl",'
     '"proxy_x_request_id":"$proxy_x_request_id",'
     '"remote_addr":"$remote_addr",'
     '"remote_user":"$remote_user",'


### PR DESCRIPTION
By doing the following:

* Renamed `main` logging format to `main_default`.
* Remove unnecessary double space between `$time_local` & `$status` from `main_default` logging format.
* Add `main_json` logging format and configure it on `access_log` to log in JSON format.

See commits for details. Each commit is an idea.