### PR TITLE
[SRE-2460] Pass through X-Forwarded-Host if set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.19.5-8
+
+* Allow passing through `X-Forwarded-Host` header if it's set.
+
 ## 1.19.5-7
 
 * Set `daemon` to `off`.

--- a/config/http.conf
+++ b/config/http.conf
@@ -21,6 +21,13 @@ http {
   port_in_redirect          off;
   server_tokens             off;
 
+  # If we receive X-Forwarded-Host, pass it through; otherwise, pass along the
+  # host used to connect to this server
+  map $http_x_forwarded_host $proxy_x_forwarded_host {
+    default $http_x_forwarded_host;
+    ''      $host;
+  }
+
   # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
   # scheme used to connect to this server
   map $http_x_forwarded_proto $proxy_x_forwarded_proto {
@@ -69,7 +76,7 @@ http {
   proxy_set_header    X-Forwarded-Ssl     $proxy_x_forwarded_ssl;
   proxy_set_header    X-Forwarded-Port    $proxy_x_forwarded_port;
   proxy_set_header    X-Request-ID        $proxy_x_request_id;
-  proxy_set_header    X-Forwarded-Host    $host;
+  proxy_set_header    X-Forwarded-Host    $proxy_x_forwarded_host;
 
   include /etc/nginx/app.conf;
 


### PR DESCRIPTION
### Why

Because if you have chained reversed proxies and the first reverse proxy sets `X-Forwarded-Host` to anything other that `Host` then the following reverse proxy will always overwrite it to `$host`. With this approach we only set it to `$host` if it wasn't set coming in.

### How It Works

To unpack what's happening here:

1. We are able to access `X-Forwarded-Host`[^http_x_forwarded_host] via `$http_x_forwarded_host` via the `$http_name`[^http_name] variable.
2. We create a new variable i.e. `$proxy_x_forwarded_host` who's value is mapped[^ngx_http_map_module.html] from `$http_x_forwarded_host`.
3. By default we set `$proxy_x_forwarded_host` to the value of `$http_x_forwarded_host` but only if it exists. If empty or it doesn't exist, we set it to `$host` (which is a way of accessing `Host`).

It's worth noting [there's security concerns around this header](https://security.stackexchange.com/questions/259279/is-it-possible-to-send-x-forward-host-headers-from-client-side) which is why it was safer to have it set to `$host` but we can handle that by always setting `X-Forwarded-Host` in the first reverse proxy to prevent clients from setting it themselves.

### References

* https://nginx.org/en/docs/http/ngx_http_map_module.html
* https://nginx.org/en/docs/http/ngx_http_core_module.html
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
* https://security.stackexchange.com/questions/259279/is-it-possible-to-send-x-forward-host-headers-from-client-side

[^http_name]:  Arbitrary request header field; the last part of a variable name is the field name converted to lower case with dashes replaced by underscores.
[^http_x_forwarded_host]: De-facto standard header for identifying the original host requested by the client in the [Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) HTTP request header.
[^ngx_http_map_module.html]: The `ngx_http_map_module` module creates variables whose values depend on values of other variables. Parameters inside the map block specify a mapping between source and resulting values.