### PR TITLE
Enable gzip compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.23.3-1
+
+* Enable gzip compression globally.
+
 ## 1.23.3
 
 * Upgrade nginx to 1.23.3.

--- a/config/http.conf
+++ b/config/http.conf
@@ -78,6 +78,46 @@ http {
   proxy_set_header    X-Request-ID        $proxy_x_request_id;
   proxy_set_header    X-Forwarded-Host    $proxy_x_forwarded_host;
 
+  gzip on;
+  gzip_comp_level 5;
+  gzip_min_length 256;
+  gzip_proxied any;
+  gzip_vary on;
+  gzip_types
+    application/atom+xml
+    application/geo+json
+    application/javascript
+    application/x-javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/rdf+xml
+    application/rss+xml
+    application/vnd.ms-fontobject
+    application/wasm
+    application/x-web-app-manifest+json
+    application/xhtml+xml
+    application/xml
+    font/eot
+    font/otf
+    font/ttf
+    image/bmp
+    image/svg+xml
+    image/vnd.microsoft.icon
+    image/x-icon
+    text/cache-manifest
+    text/calendar
+    text/css
+    text/javascript
+    text/markdown
+    text/plain
+    text/xml
+    text/vcard
+    text/vnd.rim.location.xloc
+    text/vtt
+    text/x-component
+    text/x-cross-domain-policy;
+
   include /etc/nginx/app.conf;
 
   server {


### PR DESCRIPTION
Globally enables `gzip` compression for all server locations.

Based on [H5BP](https://github.com/h5bp)'s [compression configuration for Nginx](https://github.com/h5bp/server-configs-nginx/blob/main/h5bp/web_performance/compression.conf).