### PR TITLE
Upgrade nginx to v1.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
+## 1.25.2
+
+* Upgrade to Nginx 1.25.2.
+* Upgrade to Alpine v3.18.
+
 ## 1.23.3-1
 
 * Enable gzip compression globally.
 
 ## 1.23.3
 
-* Upgrade nginx to 1.23.3.
+* Upgrade Nginx to 1.23.3.
 * Upgrade headers-more to 0.34.
 
 ## 1.19.5-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.25.2
 
 * Upgrade to Nginx 1.25.2.
-* Upgrade to Alpine v3.18.
+* Upgrade to Alpine 3.18.
 
 ## 1.23.3-1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zappi/nginx:1.23.3 as builder
+FROM zappi/nginx:1.25.2 as builder
 
 USER root
 
@@ -24,9 +24,9 @@ RUN  apk add --no-cache \
 WORKDIR /usr/src/
 
 # Download nginx source
-ARG NGINX_VERSION="1.23.3"
+ARG NGINX_VERSION="1.25.2"
 ARG NGINX_PKG="nginx-${NGINX_VERSION}.tar.gz"
-ARG NGINX_SHA="75cb5787dbb9fae18b14810f91cc4343f64ce4c24e27302136fb52498042ba54"
+ARG NGINX_SHA="05dd6d9356d66a74e61035f2a42162f8c754c97cf1ba64e7a801ba158d6c0711"
 
 RUN wget "http://nginx.org/download/${NGINX_PKG}" && \
     echo "${NGINX_SHA} *${NGINX_PKG}" | sha256sum -c - && \
@@ -48,7 +48,7 @@ RUN cd nginx && \
     make modules
 
 # Production container starts here
-FROM zappi/nginx:1.23.3
+FROM zappi/nginx:1.25.2
 
 # Copy compiled module
 COPY --from=builder /usr/src/nginx/objs/*_module.so /etc/nginx/modules/


### PR DESCRIPTION
### Overview

Upgrades Nginx to v1.25.2, which transitively also upgrades from [Alpine v3.17 to v3.18](https://hub.docker.com/layers/library/nginx/1.25.2-alpine/images/sha256-34b58b4f5c6d133d97298cbaae140283dc325ff1aeffb28176f63078baeffd14?context=explore). This should alleviate potential  [DNS issues](https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues) that [plagued](https://www.theregister.com/2023/05/16/alpine_linux_318/) Alpine for years.

See [changelog](https://nginx.org/en/CHANGES) for what's changed since v1.19.5.

### Related

* https://github.com/Intellection/docker-nginx/pull/10

### References

* https://www.theregister.com/2023/05/16/alpine_linux_318
* https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues
* https://nginx.org/en/CHANGES
