### PR TITLE
[SRE-3200] Expose $request_time as X-Server-Proxy-Time response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.25.2-1
+
+* Expose `$request_time` as `X-Server-Proxy-Time` response header.
+
 ## 1.25.2
 
 * Upgrade to Nginx 1.25.2.

--- a/config/http.conf
+++ b/config/http.conf
@@ -77,6 +77,7 @@ http {
   proxy_set_header    X-Forwarded-Port    $proxy_x_forwarded_port;
   proxy_set_header    X-Request-ID        $proxy_x_request_id;
   proxy_set_header    X-Forwarded-Host    $proxy_x_forwarded_host;
+  proxy_set_header    X-Server-Proxy-Time $request_time;
 
   gzip on;
   gzip_comp_level 5;


### PR DESCRIPTION
`$request_time` is the request processing time in seconds with a milliseconds resolution; time elapsed between the first bytes were read from the client and the log write after the last bytes were sent to the client.

### References

* https://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_time