### PR TITLE
[SRE-3200] Add X-Proxy-Backend latency headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.25.2-2
+
+* Add `X-Proxy-Backend` latency headers.
+* Remove incorrect `X-Server-Proxy-Time` configuration.
+
 ## 1.25.2-1
 
 * Expose `$request_time` as `X-Server-Proxy-Time` response header.

--- a/config/http.conf
+++ b/config/http.conf
@@ -79,6 +79,11 @@ http {
   proxy_set_header    X-Forwarded-Host    $proxy_x_forwarded_host;
   proxy_set_header    X-Server-Proxy-Time $request_time;
 
+  # Latency headers
+  add_header    X-Proxy-Backend-Connect-Time    $upstream_connect_time;
+  add_header    X-Proxy-Backend-Header-Time     $upstream_header_time;
+  add_header    X-Proxy-Backend-Total-Time      $request_time;
+
   gzip on;
   gzip_comp_level 5;
   gzip_min_length 256;

--- a/config/http.conf
+++ b/config/http.conf
@@ -77,7 +77,6 @@ http {
   proxy_set_header    X-Forwarded-Port    $proxy_x_forwarded_port;
   proxy_set_header    X-Request-ID        $proxy_x_request_id;
   proxy_set_header    X-Forwarded-Host    $proxy_x_forwarded_host;
-  proxy_set_header    X-Server-Proxy-Time $request_time;
 
   # Latency headers
   add_header    X-Proxy-Backend-Connect-Time    $upstream_connect_time;


### PR DESCRIPTION
In https://github.com/Intellection/docker-nginx-proxy/pull/15 I incorrectly used `proxy_set_header` instead of `add_header` and while trying to figure out why I am not getting the `X-Server-Proxy-Time` header, I came across [this article](https://docs.nginx.com/nginx-management-suite/acm/how-to/policies/proxy-response-headers/) that led me to the idea of latency headers. Figured it's worth adding them and seeing what we get.

For context ... in Nginx, `$upstream_header_time`, `$request_time`, and `$upstream_connect_time` are variables that can be used to monitor and analyze the performance and timing of requests and responses in a proxy or reverse proxy configuration. Here's a breakdown of the differences between these variables:

1. `$upstream_header_time`: This variable represents the time it takes to receive the response headers from the upstream (backend) server. In other words, it measures the time it takes for the backend server to process the request, generate response headers, and send them back to Nginx. This time does not include the time it takes to transfer the response body. We can use `$upstream_header_time` to monitor the backend server's processing time, which can be useful for diagnosing slow response times and optimizing our backend application.

2. `$request_time`: `$request_time` is the total time it takes to process a client request, including the time it takes for Nginx to receive the request, process it, forward it to the upstream server, receive the response, and send the response to the client. It represents the entire time elapsed during the request-response cycle. The `$request_time` includes the time represented by `$upstream_connect_time` and `$upstream_header_time`, along with any other processing time that Nginx incurs during request handling.
3. `$upstream_connect_time`: This variable measures the time it takes for Nginx to establish a connection to the upstream server. It includes the time it takes to resolve the domain name, open a connection to the server's IP address, and complete the TCP handshake. It does not include the time it takes to send or receive data. Monitoring `$upstream_connect_time` can help identify network-related performance issues, such as slow DNS resolution, network congestion, or slow backend server response.

In summary:

- `$upstream_header_time` measures the time taken to receive response headers from the backend server.
- `$request_time` measures the overall time taken to process a client request and receive a response.
- `$upstream_connect_time` measures the time taken to establish a connection to the upstream server.

These variables are useful for analyzing the performance of our Nginx proxy or reverse proxy setup and diagnosing potential bottlenecks or issues in our application infrastructure.

### Testing

I've edited the configuration manually and checked the response and here's an example ...

```http
HTTP/2 200
date: Fri, 13 Oct 2023 15:51:02 GMT
content-type: text/html; charset=utf-8
vary: Accept-Encoding
status: 200 OK
cache-control: max-age=0, private, must-revalidate
referrer-policy: no-referrer-when-downgrade
x-permitted-cross-domain-policies: none
x-xss-protection: 1; mode=block
x-request-id: b03bcc1da3faab2407349c4274065892
x-download-options: noopen
etag: W/"cf42e95ef1bc0f6a1772eb0b67d5a3f9"
x-frame-options: SAMEORIGIN
x-runtime: 0.001920
x-content-type-options: nosniff
permissions-policy: interest-cohort=()
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-robots-tag: noindex, nofollow
x-proxy-backend-connect-time: 0.000
x-proxy-backend-header-time: 0.003
x-proxy-backend-total-time: 0.004
```

### Related

* https://github.com/Intellection/docker-nginx-proxy/pull/15

### References

* https://docs.nginx.com/nginx-management-suite/acm/how-to/policies/proxy-response-headers/