### PR TITLE
Upgrade docker image to `zappi/nginx:1.25.3` on Debian Bookworm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.25.3
+
+* Use `zappi/nginx:1.25.3` as the docker base image.
+* Upgrade `headers-more-nginx-module` to `v0.37`.
+
 ## 1.25.2-3
 
 * Log `X-Proxy-Backend` latency headers.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Intellection/sre
+* @Intellection/SRE

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,9 @@ RUN wget "http://nginx.org/download/${NGINX_PKG}" && \
     tar --no-same-owner -xzf ${NGINX_PKG} --one-top-level=nginx --strip-components=1
 
 # Download headers-more module source
-ARG HEADERS_MORE_VERSION="0.34"
+ARG HEADERS_MORE_VERSION="0.37"
 ARG HEADERS_MORE_PKG="v${HEADERS_MORE_VERSION}.tar.gz"
-ARG HEADERS_MORE_SHA="0c0d2ced2ce895b3f45eb2b230cd90508ab2a773299f153de14a43e44c1209b3"
+ARG HEADERS_MORE_SHA="cf6e169d6b350c06d0c730b0eaf4973394026ad40094cddd3b3a5b346577019d"
 
 RUN wget "https://github.com/openresty/headers-more-nginx-module/archive/${HEADERS_MORE_PKG}" && \
     echo "${HEADERS_MORE_SHA} *${HEADERS_MORE_PKG}" | sha256sum -c - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zappi/nginx:1.25.2 as builder
+FROM zappi/nginx:1.25.3 as builder
 
 USER root
 
@@ -24,9 +24,9 @@ RUN  apk add --no-cache \
 WORKDIR /usr/src/
 
 # Download nginx source
-ARG NGINX_VERSION="1.25.2"
+ARG NGINX_VERSION="1.25.3"
 ARG NGINX_PKG="nginx-${NGINX_VERSION}.tar.gz"
-ARG NGINX_SHA="05dd6d9356d66a74e61035f2a42162f8c754c97cf1ba64e7a801ba158d6c0711"
+ARG NGINX_SHA="64c5b975ca287939e828303fa857d22f142b251f17808dfe41733512d9cded86"
 
 RUN wget "http://nginx.org/download/${NGINX_PKG}" && \
     echo "${NGINX_SHA} *${NGINX_PKG}" | sha256sum -c - && \
@@ -48,7 +48,7 @@ RUN cd nginx && \
     make modules
 
 # Production container starts here
-FROM zappi/nginx:1.25.2
+FROM zappi/nginx:1.25.3
 
 # Copy compiled module
 COPY --from=builder /usr/src/nginx/objs/*_module.so /etc/nginx/modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,24 +2,15 @@ FROM zappi/nginx:1.25.3 as builder
 
 USER root
 
-# Install build dependencies
-RUN  apk add --no-cache \
-      alpine-sdk \
-      bash \
-      findutils \
-      gcc \
-      gd-dev \
-      geoip-dev \
-      libc-dev \
-      libedit-dev \
-      libxslt-dev \
-      linux-headers \
-      make \
-      mercurial \
-      openssl-dev \
-      pcre-dev \
-      perl-dev \
-      zlib-dev
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      ca-certificates \
+      libpcre3 \
+      libpcre3-dev \
+      wget \
+      zlib1g \
+      zlib1g-dev
 
 WORKDIR /usr/src/
 
@@ -43,8 +34,7 @@ RUN wget "https://github.com/openresty/headers-more-nginx-module/archive/${HEADE
 
 # Compile nginx with headers-more module using original configure arguments
 RUN cd nginx && \
-    CONFIGURATION_ARGUMENTS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') && \
-    sh -c "./configure --with-compat ${CONFIGURATION_ARGUMENTS} --add-dynamic-module=/usr/src/headers-more" && \
+    ./configure --with-compat --add-dynamic-module=/usr/src/headers-more && \
     make modules
 
 # Production container starts here


### PR DESCRIPTION
Because [the base image has the version updated and it's also moved off Alpine](https://github.com/Intellection/docker-nginx/pull/11).


### Testing

Build and run it ...

```console
$ docker-compose build                                          
[+] Building 130.8s (13/13) FINISHED                                                                                                                                             docker:desktop-linux
 => [proxy internal] load build definition from Dockerfile                                                                                                                                       0.0s
 => => transferring dockerfile: 1.62kB                                                                                                                                                           0.0s
 => [proxy internal] load .dockerignore                                                                                                                                                          0.0s
 => => transferring context: 136B                                                                                                                                                                0.0s
 => [proxy internal] load metadata for docker.io/zappi/nginx:1.25.3                                                                                                                              1.9s
 => [proxy builder 1/6] FROM docker.io/zappi/nginx:1.25.3@sha256:cc2182d1db65e056cd873b8e170b86516fe39623009a0567bca4fc3f69368321                                                               22.7s
 => => resolve docker.io/zappi/nginx:1.25.3@sha256:cc2182d1db65e056cd873b8e170b86516fe39623009a0567bca4fc3f69368321                                                                              0.0s
 => => sha256:2f44b7a888fa005d07c031d3cfad2a1c0344207def2ab9dbb97712425ff812c1 29.13MB / 29.13MB                                                                                                20.7s
 => => sha256:8b7dd3ed1dc34cc1caba38bbbf22bceda5bd2e7c4e1b3c11ca64cda2ed186a2c 41.37MB / 41.37MB                                                                                                15.8s
 => => sha256:cc2182d1db65e056cd873b8e170b86516fe39623009a0567bca4fc3f69368321 2.40kB / 2.40kB                                                                                                   0.0s
 => => sha256:ee74c6821d1dbfbfc5afe4cee132370bc1fbee2a7d4ae51c9b91673e25231948 8.55kB / 8.55kB                                                                                                   0.0s
 => => sha256:35497dd96569b9139cd388fd7107df32ccdc1449b205536bce0968b2dec3e7dc 628B / 628B                                                                                                       3.2s
 => => sha256:36664b6ce66b304efa7ba48eb960133a085c2ec800a9f8887df94a82679334c1 955B / 955B                                                                                                       4.2s
 => => sha256:2d455521f76cee8b8b2e21457075cc500c60373d70acb217f12838818fc3da90 366B / 366B                                                                                                       4.8s
 => => sha256:dc9c4fdb83d69ef5986ec344c6b75606b3a417c7434268cb6995962be5312f14 1.21kB / 1.21kB                                                                                                   5.1s
 => => sha256:8056d2bcf3b682573ee5b0c176c1209df285d5be0df98ec6ae08bf7421179b74 1.40kB / 1.40kB                                                                                                   5.6s
 => => sha256:8d4cf47c4dbbc321d5871e7eee5eb7832a9627bdc1f9d55456af0c32e96d669f 500B / 500B                                                                                                       5.9s
 => => sha256:1aeeb11aea27fd977730dbbb9681f0877c705ecda707b50ea996f7957fb7efff 622B / 622B                                                                                                       6.2s
 => => sha256:750439207b935276a524d5358722b9c2ceb09d1f555cace7bb2b5724b0d94424 820B / 820B                                                                                                       6.6s
 => => extracting sha256:2f44b7a888fa005d07c031d3cfad2a1c0344207def2ab9dbb97712425ff812c1                                                                                                        1.1s
 => => extracting sha256:8b7dd3ed1dc34cc1caba38bbbf22bceda5bd2e7c4e1b3c11ca64cda2ed186a2c                                                                                                        0.6s
 => => extracting sha256:35497dd96569b9139cd388fd7107df32ccdc1449b205536bce0968b2dec3e7dc                                                                                                        0.0s
 => => extracting sha256:36664b6ce66b304efa7ba48eb960133a085c2ec800a9f8887df94a82679334c1                                                                                                        0.0s
 => => extracting sha256:2d455521f76cee8b8b2e21457075cc500c60373d70acb217f12838818fc3da90                                                                                                        0.0s
 => => extracting sha256:dc9c4fdb83d69ef5986ec344c6b75606b3a417c7434268cb6995962be5312f14                                                                                                        0.0s
 => => extracting sha256:8056d2bcf3b682573ee5b0c176c1209df285d5be0df98ec6ae08bf7421179b74                                                                                                        0.0s
 => => extracting sha256:8d4cf47c4dbbc321d5871e7eee5eb7832a9627bdc1f9d55456af0c32e96d669f                                                                                                        0.0s
 => => extracting sha256:1aeeb11aea27fd977730dbbb9681f0877c705ecda707b50ea996f7957fb7efff                                                                                                        0.0s
 => => extracting sha256:750439207b935276a524d5358722b9c2ceb09d1f555cace7bb2b5724b0d94424                                                                                                        0.0s
 => [proxy internal] load build context                                                                                                                                                          0.0s
 => => transferring context: 11.43kB                                                                                                                                                             0.0s
 => [proxy builder 2/6] RUN apt-get update -y &&     apt-get install --no-install-recommends -y       build-essential       ca-certificates       libpcre3       libpcre3-dev       wget        46.6s
 => [proxy builder 3/6] WORKDIR /usr/src/                                                                                                                                                        0.0s
 => [proxy builder 4/6] RUN wget "http://nginx.org/download/nginx-1.25.3.tar.gz" &&     echo "64c5b975ca287939e828303fa857d22f142b251f17808dfe41733512d9cded86 *nginx-1.25.3.tar.gz" | sha256su  6.3s
 => [proxy builder 5/6] RUN wget "https://github.com/openresty/headers-more-nginx-module/archive/v0.37.tar.gz" &&     echo "cf6e169d6b350c06d0c730b0eaf4973394026ad40094cddd3b3a5b346577019d *v  2.3s
 => [proxy builder 6/6] RUN cd nginx &&     ./configure --with-compat --add-dynamic-module=/usr/src/headers-more &&     make modules                                                            50.7s
 => [proxy stage-1 2/3] COPY --from=builder /usr/src/nginx/objs/*_module.so /etc/nginx/modules/                                                                                                  0.0s
 => [proxy stage-1 3/3] COPY ./config/ /etc/nginx/                                                                                                                                               0.0s
 => [proxy] exporting to image                                                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                                                          0.0s
 => => writing image sha256:c51915a44f2cdce06bac55d4cc2cc8b1d85a8bf84395f33c6597db448a99e516                                                                                                     0.0s
 => => naming to docker.io/library/nginx-proxy:latest

$ docker-compose up -d 
[+] Running 2/0
 ✔ Container docker-nginx-proxy-app-1    Running                                                                                                                 0.0s 
 ✔ Container docker-nginx-proxy-proxy-1  Running
```

Make a request and check the logs ...

```console
$ curl -I  http://127.0.0.1:8080
HTTP/1.1 200 OK
Date: Thu, 18 Jan 2024 11:37:06 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 12226
Connection: keep-alive
Vary: Accept-Encoding
Accept-Ranges: bytes
Etag: "qlgk6n9fm"
Last-Modified: Thu, 17 Dec 2020 00:32:47 GMT
X-Robots-Tag: "noindex, nofollow"
X-Proxy-Backend-Connect-Time: 0.001
X-Proxy-Backend-Header-Time: 0.003
X-Proxy-Backend-Total-Time: 0.004

$ docker-compose logs 
app-1    | {"level":"info","ts":1705577727.480575,"msg":"using provided configuration","config_file":"/etc/caddy/Caddyfile","config_adapter":"caddyfile"}
app-1    | {"level":"info","ts":1705577727.4821959,"logger":"admin","msg":"admin endpoint started","address":"tcp/localhost:2019","enforce_origin":false,"origins":["localhost:2019","[::1]:2019","127.0.0.1:2019"]}
app-1    | {"level":"info","ts":1705577727.4822962,"logger":"http","msg":"server is listening only on the HTTP port, so no automatic HTTPS will be applied to this server","server_name":"srv0","http_port":80}
app-1    | 2024/01/18 11:35:27 [INFO][cache:0x40004c0ba0] Started certificate maintenance routine
app-1    | {"level":"info","ts":1705577727.4829206,"logger":"tls","msg":"cleaned up storage units"}
app-1    | {"level":"info","ts":1705577727.4831488,"msg":"autosaved config","file":"/config/caddy/autosave.json"}
proxy-1  | {"body_bytes_sent":"0","host":"127.0.0.1","http_connection":"","http_referer":"","http_upgrade":"","http_user_agent":"curl/8.5.0","http_x_amzn_trace_id":"","http_x_forwarded_for":"","http_x_proxy_backend_connect_time":"0.001","http_x_proxy_backend_header_time":"0.003","http_x_proxy_backend_total_time":"0.004","proxy_connection":"","proxy_x_forwarded_port":"8080","proxy_x_forwarded_proto":"http","proxy_x_forwarded_ssl":"off","proxy_x_request_id":"c02dde6a2e73fd53b142de5c1bafa99f","remote_addr":"192.168.65.1","remote_user":"","request":"HEAD / HTTP/1.1","request_length":"78","request_time":"0.004","status": "200","time_iso8601":"2024-01-18T11:37:06+00:00"}
```

The headers in the response match what you would expect from ...

https://github.com/Intellection/docker-nginx-proxy/blob/542c3b618f9b1db9fb4cd30ac8dee0470e39187c/example/app.conf#L6-L10

### Related

* https://github.com/Intellection/docker-nginx/pull/11
* https://github.com/openresty/headers-more-nginx-module/issues/116
* https://github.com/openresty/headers-more-nginx-module/issues/146
* https://github.com/openresty/headers-more-nginx-module/issues/156

### References

* https://openresty.org/en/headers-more-nginx-module.html
* https://github.com/openresty/headers-more-nginx-module
* https://github.com/nginx-with-docker/ngx_http_headers_more_filter_module
* https://stackoverflow.com/questions/14045720/nginx-configure-error-ubuntu-12-04
* https://askubuntu.com/questions/980145/cant-add-nginx-module-requires-zlib
* https://serverfault.com/questions/416571/cant-compile-nginx-with-ssl-support-openssl-not-found