### PR TITLE
[SRE-3430] Add x-request-start header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.25.4
+
+* Add `X-Request-Start` header set to current time with millisecond precision.
+* Update base image to `zappi/nginx:1.25.4`.
+
 ## 1.25.3-1
 
 * Add OpenTelemetry (OTel) module i.e. `nginx-module-otel`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zappi/nginx:1.25.3 as builder
+FROM zappi/nginx:1.25.4 as builder
 
 USER root
 
@@ -16,9 +16,9 @@ RUN apt-get update -y && \
 WORKDIR /usr/src/
 
 # Download nginx source
-ARG NGINX_VERSION="1.25.3"
+ARG NGINX_VERSION="1.25.4"
 ARG NGINX_PKG="nginx-${NGINX_VERSION}.tar.gz"
-ARG NGINX_SHA="64c5b975ca287939e828303fa857d22f142b251f17808dfe41733512d9cded86"
+ARG NGINX_SHA="760729901acbaa517996e681ee6ea259032985e37c2768beef80df3a877deed9"
 RUN wget "http://nginx.org/download/${NGINX_PKG}" && \
     echo "${NGINX_SHA} *${NGINX_PKG}" | sha256sum -c - && \
     tar --no-same-owner -xzf ${NGINX_PKG} --one-top-level=nginx --strip-components=1
@@ -37,7 +37,7 @@ RUN cd nginx && \
     make modules
 
 # Production container starts here
-FROM zappi/nginx:1.25.3
+FROM zappi/nginx:1.25.4
 
 USER root
 

--- a/config/http.conf
+++ b/config/http.conf
@@ -77,6 +77,7 @@ http {
   proxy_set_header    X-Forwarded-Port    $proxy_x_forwarded_port;
   proxy_set_header    X-Request-ID        $proxy_x_request_id;
   proxy_set_header    X-Forwarded-Host    $proxy_x_forwarded_host;
+  proxy_set_header    X-Request-Start     "t=${msec}";
 
   # Latency headers
   add_header    X-Proxy-Backend-Connect-Time    $upstream_connect_time;


### PR DESCRIPTION
### Overview

Adds `X-Request-Start` header set to current time with millisecond precision, enabling the measurement of request queue timing.

Additionally, updates the base image to `zappi/nginx:1.25.4`, which upgrades Nginx to v1.25.4.

### Related

* https://github.com/Intellection/docker-nginx/pull/12