### PR TITLE
[SRE-4808] Upgrade Nginx to v1.27.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.27.4
+
+* Update base image to `zappi/nginx:1.27.4`.
+* Fix pid file perimssion denied error.
+
 ## 1.27.1-2
 
 * Upgrade `headers-more-nginx-module` to `v0.38`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zappi/nginx:1.27.1 AS builder
+FROM zappi/nginx:1.27.4 AS builder
 
 USER root
 
@@ -16,9 +16,9 @@ RUN apt-get update -y && \
 WORKDIR /usr/src/
 
 # Download nginx source
-ARG NGINX_VERSION="1.27.1"
+ARG NGINX_VERSION="1.27.4"
 ARG NGINX_PKG="nginx-${NGINX_VERSION}.tar.gz"
-ARG NGINX_SHA="bd7ba68a6ce1ea3768b771c7e2ab4955a59fb1b1ae8d554fedb6c2304104bdfc"
+ARG NGINX_SHA="294816f879b300e621fa4edd5353dd1ec00badb056399eceb30de7db64b753b2"
 RUN wget "http://nginx.org/download/${NGINX_PKG}" && \
     echo "${NGINX_SHA} *${NGINX_PKG}" | sha256sum -c - && \
     tar --no-same-owner -xzf ${NGINX_PKG} --one-top-level=nginx --strip-components=1
@@ -37,7 +37,7 @@ RUN cd nginx && \
     make modules
 
 # Production container starts here
-FROM zappi/nginx:1.27.1
+FROM zappi/nginx:1.27.4
 
 USER root
 

--- a/config/main.conf
+++ b/config/main.conf
@@ -1,5 +1,7 @@
 daemon off;
 
+pid /tmp/nginx.pid;
+
 worker_processes        auto;
 worker_rlimit_nofile    8192;
 worker_shutdown_timeout 240s;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.7'
 services:
   app:
     image: caddy:2.1.1-alpine


### PR DESCRIPTION
### Overview

Upgrades Nginx to [v1.27.4](https://github.com/nginx/nginx/releases/tag/release-1.27.4) to fix the following error:

```
nginx: [emerg] module "/etc/nginx/modules/ngx_http_headers_more_filter_module.so" version 1027001 instead of 1027004 in /etc/nginx/nginx.conf:1
```

Additionally, fixes the following [pid file related](https://github.com/nginx/docker-nginx-unprivileged/blob/main/README.md#troubleshooting-tips) error:

```
nginx: [emerg] open() "/var/run/nginx.pid" failed (13: Permission denied)
```

### Related

* https://github.com/Intellection/docker-nginx/pull/15

### References

* https://nginx.org/en/CHANGES
* https://github.com/nginx/docker-nginx-unprivileged/blob/main/README.md#troubleshooting-tips
