### PR TITLE
chore: align codeowners with platform engineering

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Intellection/SRE
+* @Intellection/platform-engineering


### PR DESCRIPTION
Replaces the legacy SRE/DevOps CODEOWNERS reference and section label with @Intellection/platform-engineering while preserving the existing ownership scope. Linear: https://linear.app/zappi/issue/EL-160/align-github-teams-repository-permissions-and-codeowners